### PR TITLE
Create trigger-maven

### DIFF
--- a/.github/workflows/trigger-maven
+++ b/.github/workflows/trigger-maven
@@ -1,0 +1,29 @@
+name: Trigger Maven Repository Update
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  trigger-maven-deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Get release info
+      id: release
+      run: |
+        echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
+        echo "SUBMODULE=${GITHUB_REPOSITORY##*/}" >> $GITHUB_OUTPUT
+
+    - name: Trigger Optimization repository deployment
+      uses: peter-evans/repository-dispatch@v3
+      with:
+        token: ${{ secrets.OPTIMIZATION_REPO_TOKEN }}
+        repository: ${{ github.repository_owner }}/Optimization
+        event-type: submodule-release
+        client-payload: |
+          {
+            "submodule": "${{ steps.release.outputs.SUBMODULE }}",
+            "version": "${{ steps.release.outputs.VERSION }}",
+            "repository": "${{ github.repository }}",
+            "release_url": "${{ github.event.release.html_url }}"
+          }


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate triggering updates to the Maven repository upon publishing a release. The workflow ensures that submodule releases are communicated to the Optimization repository for deployment.

### New GitHub Actions workflow:

* [`.github/workflows/trigger-maven`](diffhunk://#diff-37602c915e2c6670bb40be88b4c562f4a0046c09dc64d0340a7e65c2f2630a38R1-R29): Added a workflow named "Trigger Maven Repository Update" that listens for `release` events of type `published`. It retrieves release information (version and submodule) and triggers a deployment in the Optimization repository using the `peter-evans/repository-dispatch` action.