### PR TITLE
Update version number to 0.1.0 for release preparation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>nl.jessenagel.optimization</groupId>
     <artifactId>cemtrouting</artifactId>
-    <version>1.0.3-ALPHA</version>
+    <version>0.1.0</version>
     <name>CEMTRouting</name>
     <url/>
     <licenses>


### PR DESCRIPTION
This pull request includes a version downgrade in the `pom.xml` file. The version of the `cemtrouting` artifact has been changed from `1.0.3-ALPHA` to `0.1.0` to reflect an earlier development stage.