### PR TITLE
Update and rename trigger-maven to trigger-maven.yml

### DIFF
--- a/.github/workflows/trigger-maven.yml
+++ b/.github/workflows/trigger-maven.yml
@@ -3,6 +3,7 @@ name: Trigger Maven Repository Update
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   trigger-maven-deploy:


### PR DESCRIPTION
This pull request includes a small addition to the `.github/workflows/trigger-maven.yml` file (renamed from `.github/workflows/trigger-maven`). The change adds a `workflow_dispatch` event trigger to allow manual execution of the workflow.